### PR TITLE
fix: Included file import now serves warning instead of error when the

### DIFF
--- a/src/lib/components/Gms2IncludedFile.ts
+++ b/src/lib/components/Gms2IncludedFile.ts
@@ -134,7 +134,7 @@ export class Gms2IncludedFile {
       if(matchingFile.directoryRelative != directoryRelative){
         logWarning(oneline`
           A file by name ${fileName} already exists in a different subdirectory.
-          Check to make sure that it is the file that you intend to change!
+          Check to make sure that it is the file that you intended to change!
         `);
       }
       return matchingFile;


### PR DESCRIPTION
file subdir does not match. Files without subdir will be put in the root
directory instead of a "NEW" subdir.