### PR TITLE
fix(docs): correct invalid instruction in programmatic use

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Stitch is developed by [Butterscotch Shenanigans](https://www.bscotch.net) ("Bsc
 ### ⌨ Programmatic:
 
 + In the terminal, navigate to your Node.js project
-+ Locally install Stitch: `npm install --global @bscotch/stitch`
++ Locally install Stitch: `npm install @bscotch/stitch`
 + In your code, import the `Gms2Project` class from Stitch
   + ESM style: `import {Gms2Project} from "@bscotch/stitch"`
   + CommonJS style: `const {Gms2Project} = require('@bscotch/stitch')`


### PR DESCRIPTION
Programmatic use section specifies to install locally, but still shows to pass the --global flag.