### PR TITLE
chore: Remove the 'master' branch push so that only the primary 'deve…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "watch": "tsc -w && tsc-alias -w",
     "preversion": "git checkout develop && npm test",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0 && prettier src -w && git add -A",
-    "postversion": "git push origin develop && git checkout master && git merge develop && git push origin master --follow-tags && npm publish && git checkout develop",
+    "postversion": "git push --follow-tags && npm publish",
     "cli-watch-test": "npm run build && node build/test/lib/runResetSandbox.js && node build/cli/stitch-add-sprites.js --force --watch --source sample-assets/sprites -t \"sand box\""
   },
   "repository": {


### PR DESCRIPTION
…lop' branch will be used. This will help to simplify workflows.