### PR TITLE
Draft publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,7 @@ jobs:
           node-version: 14.x
       - run: npm i
       - run: npm run test
-
-      # Bump version
+      # Parse pushed commit messages
       - name: Find out what version bump is needed
         id: version-bump-type
         uses: actions/github-script@v4
@@ -44,7 +43,7 @@ jobs:
           script: |
             const bumpTypes = {
               minor: ['feat','feature','deps','dependency','dependencies'],
-              patch: ['fix','bugfix','perf','performance']
+              patch: ['fix','bugfix','perf','performance','docs']
             };
             const allBumpTypes = [...bumpTypes.minor, ...bumpTypes.patch];
             console.log({commits: context.payload.commits});
@@ -66,9 +65,21 @@ jobs:
               return 'patch'
             }
             return 'skip'
+
+      - name: Store bump version type as env var BUMP
+        run: echo "BUMP=${{steps.version-bump-type.outputs.result}}" >> $GITHUB_ENV
+      
+      # Version
+      - name: Bump the version, pushing a version commit
+        if: ${{ env.BUMP != 'skip'}}
+        run: "npm version $BUMP"
+
+      # TODO: Publish!
+
       - name: TEST (FAKE) BUMP
-        if: ${{steps.version-bump-type.outputs.result != 'skip'}}
-        run: echo "BUMPED! ${{steps.version-bump-type.outputs.result}}"
+        if: ${{ env.BUMP != 'skip'}}
+        run: echo "BUMPED! $BUMP"
+
 
       # - name: Bump the version
       #   if: ${{contains(['major','minor','patch'],steps.version-bump-type.outputs.result)}}

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "test": "npm run build && mocha -r source-map-support/register --bail -S ./build/test/",
     "build": "rm -rf build && tsc && tsc-alias",
     "watch": "tsc -w && tsc-alias -w",
-    "preversion": "git checkout develop && npm test",
+    "preversion": "npm run _require-develop && npm run _require-ci",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0 && prettier src -w && git add -A",
-    "postversion": "git push --follow-tags && npm publish",
-    "cli-watch-test": "npm run build && node build/test/lib/runResetSandbox.js && node build/cli/stitch-add-sprites.js --force --watch --source sample-assets/sprites -t \"sand box\""
+    "postversion": "git push origin develop --follow-tags",
+    "cli-watch-test": "npm run build && node build/test/lib/runResetSandbox.js && node build/cli/stitch-add-sprites.js --force --watch --source sample-assets/sprites -t \"sand box\"",
+    "_require-develop": "[ \"$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)\" == \"develop\" ] || exit 1",
+    "_require-ci": "[ \"${GITHUB_ACTIONS}\" == \"true\" ] || exit 1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- build: Change npm versioning scripts in prep for CI versioning: error out if not in GitHub or not on Dev, and reduce actions taken during versioning.
- build: Add version bumping to the publish workflow.
