### PR TITLE
feat: Get GmlSpec.xml directly from the locally installed runtime and some changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ Thumbs.db
 !.env.project
 !.env.vault
 .flaskenv*
+packages/vscode/.npmrc

--- a/packages/vscode/language-configuration.json
+++ b/packages/vscode/language-configuration.json
@@ -15,6 +15,7 @@
     { "open": "@\"", "close": "\"", "notIn": ["string", "comment"] },
     { "open": "@'", "close": "'", "notIn": ["string", "comment"] },
     { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+    { "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
     { "open": "/*", "close": " */", "notIn": ["string"] }
   ],
   "surroundingPairs": [

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -91,12 +91,14 @@
         },
         "stitch.gmlSpec.source": {
           "title": "GameMaker GmlSpec.xml file source",
-          "type": ["string"],
+          "type": [
+            "string"
+          ],
           "enum": [
-						"localRuntime",
-						"external",
+            "localRuntime",
+            "external",
             "internal"
-					],
+          ],
           "default": "localRuntime",
           "description": "Specifies the GmlSpec.xml source. Obtained by default from the installed runtime.It needs to restart vscode after modification to take effect"
         },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -228,6 +228,9 @@
     "onCommand:stitch.openIde",
     "onCommand:stitch.createProject"
   ],
+  "dependencies": {
+    "glob": "9.2.1"
+  },
   "devDependencies": {
     "@bscotch/gml-parser": "workspace:*",
     "@bscotch/pathy": "^2.6.0",
@@ -274,9 +277,5 @@
       ]
     },
     "hoverProvider": "true"
-  },
-  "dependencies": {
-    "glob": "9.2.1",
-    "tsc": "2.0.4"
   }
 }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -88,10 +88,35 @@
           ],
           "default": null,
           "description": "Specifies the path to a GameMaker project to use as a template to clone when creating a new project via the explorer context menu. Defaults to a simple project with a single room and a single object."
+        },
+        "stitch.gmlSpec.source": {
+          "title": "GameMaker GmlSpec.xml file source",
+          "type": ["string"],
+          "enum": [
+						"localRuntime",
+						"external",
+            "internal"
+					],
+          "default": "localRuntime",
+          "description": "Specifies the GmlSpec.xml source. Obtained by default from the installed runtime.It needs to restart vscode after modification to take effect"
+        },
+        "stitch.gmlSpec.path": {
+          "title": "GameMaker GmlSpec.xml file path",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Specifies the path to a GmlSpec.xml file when \"gmlSpec.source\" is \"external\"."
         }
       }
     },
     "grammars": [
+      {
+        "language": "yy",
+        "scopeName": "source.yyp",
+        "path": "./syntaxes/yyp.tmLanguage.json"
+      },
       {
         "language": "gml",
         "scopeName": "source.gml",
@@ -110,7 +135,12 @@
     ],
     "languages": [
       {
-        "id": "jsonc",
+        "id": "yy",
+        "aliases": [
+          "GameMaker YY & YYP File",
+          "yy",
+          "yyp"
+        ],
         "configuration": "./language-configuration.json",
         "extensions": [
           ".yy",
@@ -244,5 +274,9 @@
       ]
     },
     "hoverProvider": "true"
+  },
+  "dependencies": {
+    "glob": "9.2.1",
+    "tsc": "2.0.4"
   }
 }

--- a/packages/vscode/src/language.mts
+++ b/packages/vscode/src/language.mts
@@ -5,6 +5,8 @@ import vscode from 'vscode';
 import { debounce } from './debounce.mjs';
 import { GameMakerProject } from './language.project.mjs';
 import { GmlSpec, parseSpec } from './spec.mjs';
+import glob from 'glob';
+import os from 'os';
 
 export class GmlProvider
   implements
@@ -259,7 +261,26 @@ export class GmlProvider
   static async activate(ctx: vscode.ExtensionContext) {
     this.ctx ||= ctx;
     if (!this.provider) {
-      this.provider = new GmlProvider(await parseSpec());
+      let gmlSpecFilePath;
+      const gmlSpecSource = vscode.workspace.getConfiguration('stitch').get<string | null>('gmlSpec.source');
+      const gmlSpecFilePathFromSettings = vscode.workspace.getConfiguration('stitch').get<string | null>('gmlSpec.path');
+      if (gmlSpecSource === "external" && gmlSpecFilePathFromSettings !== null) {
+        gmlSpecFilePath = gmlSpecFilePathFromSettings;
+      } else if (gmlSpecSource === "localRuntime") {
+        let runtimeLocalPath;
+        if (os.type() == 'Windows_NT') {
+          runtimeLocalPath = "C:/ProgramData/GameMakerStudio2/Cache/runtimes/";
+        } else if (os.type() == 'Darwin') {
+          runtimeLocalPath = "/Users/Shared/GameMakerStudio2/Cache/runtimes/";  // (LiarOnce) Need testing because I don't have any macOS devices.
+        } else if (os.type() == 'Linux') {
+          runtimeLocalPath = "~/.local/GameMakerStudio2-Beta/Cache/runtimes/";  // GameMaker IDE in Linux only available in Beta channel
+        }
+        let runtimeGlob = await glob(runtimeLocalPath + '**/GmlSpec.xml', {});
+        gmlSpecFilePath = runtimeGlob[0]; // Always get the latest version of the installed runtimes' GmlSpec.xml files on local
+      } else if (gmlSpecSource === "internal"){
+        gmlSpecFilePath = null;
+      }
+      this.provider = new GmlProvider(await parseSpec(gmlSpecFilePath as string));
       const onChangeDoc = debounce((event: vscode.TextDocumentChangeEvent) => {
         const doc = event.document;
         if (doc.languageId !== 'gml') {

--- a/packages/vscode/src/spec.mts
+++ b/packages/vscode/src/spec.mts
@@ -3,13 +3,10 @@ import { parseStringPromise } from 'xml2js';
 import { GmlSpec, gmlSpecSchema } from './spec.schemas.mjs';
 export type { GmlSpec } from './spec.schemas.mjs';
 
-// @ts-expect-error
-import fallbackSpec from '../samples/GmlSpec.xml';
+let fallbackSpec = require('../samples/GmlSpec.xml');
 
 export async function parseSpec(specFilePath?: string): Promise<GmlSpec> {
-  const specRaw = specFilePath
-    ? await readFile(specFilePath, 'utf8')
-    : (fallbackSpec as string);
-  const asJson = await parseStringPromise(specRaw);
+  const specRaw = specFilePath ? await readFile(specFilePath, 'utf8') : (fallbackSpec as string);
+  const asJson = await parseStringPromise(specRaw.replace("\ufeff", ""), {trim:true, normalize: true}); // Prevent possible errors: "Non-white space before first tag"
   return gmlSpecSchema.parse(asJson);
 }

--- a/packages/vscode/syntaxes/yyp.tmLanguage.json
+++ b/packages/vscode/syntaxes/yyp.tmLanguage.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "fileTypes": ["yy", "yyp"],
+  "name": "GameMaker YY & YYP File",
+  "patterns": [
+    {
+        "name": "source.yyp",
+        "include": "source.json"
+    }
+  ],
+  "repository": {},
+  "scopeName": "source.yyp"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,7 @@ importers:
       '@types/xml2js': 0.4.11
       '@vscode/vsce': 2.18.0
       esbuild: ^0.17.11
+      glob: 9.2.1
       nodemon: ^2.0.21
       plist: 3.0.6
       typescript: 5.0.1-rc
@@ -412,6 +413,8 @@ importers:
       zod: ^3.21.2
       zod-to-json-schema: 3.20.4
       zx: ^7.2.0
+    dependencies:
+      glob: 9.2.1
     devDependencies:
       '@bscotch/gml-parser': link:../parser
       '@bscotch/pathy': 2.6.0
@@ -4196,7 +4199,6 @@ packages:
       minimatch: 7.4.2
       minipass: 4.2.4
       path-scurry: 1.6.1
-    dev: true
 
   /global-agent/3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -5073,7 +5075,6 @@ packages:
   /lru-cache/7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
-    dev: true
 
   /lzma-native/8.0.6:
     resolution: {integrity: sha512-09xfg67mkL2Lz20PrrDeNYZxzeW7ADtpYFbwSQh9U8+76RIzx5QsJBMy8qikv3hbUPfpy6hqwxt6FcGK81g9AA==}
@@ -5286,7 +5287,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimist/0.0.8:
     resolution: {integrity: sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==}
@@ -5344,7 +5344,6 @@ packages:
   /minipass/4.2.4:
     resolution: {integrity: sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /minizlib/2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -6127,7 +6126,6 @@ packages:
     dependencies:
       lru-cache: 7.18.3
       minipass: 4.2.4
-    dev: true
 
   /path-to-regexp/3.2.0:
     resolution: {integrity: sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==}


### PR DESCRIPTION
1. Get GmlSpec.xml directly from the locally installed runtime (default)
2. Now you can specify the GmlSpec.xml path to use the self-made file (e.g. [GmlSpec-CN](https://github.com/GamemakerChina/GmlSpec-CN))
3. Add simple syntax highlighting for `YY` and `YYP`  (No warning will be prompted in VSCode)