### PR TITLE
feat: Support select channel manually.

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -99,6 +99,19 @@
           "default": null,
           "description": "Specifies the path to a GameMaker project to use as a template to clone when creating a new project via the explorer context menu. Defaults to a simple project with a single room and a single object."
         },
+        "stitch.gm.channel": {
+          "title": "GameMaker Channel",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "GameMakerStudio2",
+            "GameMakerStudio2-Beta",
+            "GameMakerStudio2-LTS"
+          ],
+          "default": "GameMakerStudio2",
+          "description": "Manually specify the channel of GameMaker, default is Stable channel (GameMakerStudio2) \nNote: only \"GameMakerStudio2-Beta\" can be used in Linux"
+        },
         "stitch.gmlSpec.source": {
           "title": "GameMaker GmlSpec.xml file source",
           "type": [
@@ -110,7 +123,7 @@
             "external"
           ],
           "default": "internal",
-          "description": "Specifies the GmlSpec.xml source. Obtained by default from the installed runtime. It needs to restart vscode after modification to take effect. Falls back to `internal`, an internal copy of a recent version of the GmlSpec.xml."
+          "description": "Specifies the GmlSpec.xml source. Obtained by default from the installed runtime. Falls back to `internal`, an internal copy of a recent version of the GmlSpec.xml. \nNote: It needs to restart vscode after modification to take effect. "
         },
         "stitch.gmlSpec.path": {
           "title": "GameMaker GmlSpec.xml file path",

--- a/packages/vscode/syntaxes/yyp.tmLanguage.json
+++ b/packages/vscode/syntaxes/yyp.tmLanguage.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "fileTypes": ["yy", "yyp"],
-  "name": "GameMaker YY & YYP File",
+  "name": "GameMaker Metadata",
   "patterns": [
     {
         "name": "source.yyp",


### PR DESCRIPTION
Now you can manually select the channel of GameMaker.
I don't know the installation path of Dev channel because I don't have permission, but I think it should be the same as Beta (`GameMakerStudio2-Beta`).

Maybe they can use aliases to refer to these for future use, for example:
```json
{
    "Stable": {
        "name": "Stable",
        "path": "GameMakerStudio2"
    },
    "LTS": {
        "name": "LTS",
        "path": "GameMakerStudio2-LTS"
    },
    "Beta": {
        "name": "Beta",
        "path": "GameMakerStudio2-Beta"
    }
}
```