### PR TITLE
feature: add direct link to github issues in desktop settings

### DIFF
--- a/packages/desktop-server/src/lib/trpc.router.ts
+++ b/packages/desktop-server/src/lib/trpc.router.ts
@@ -105,6 +105,15 @@ export const router = t.router({
       const projects = await req.ctx.config.addProjects(req.input.directory);
       return { added: toJson(projects) };
     }),
+  openIssues: t.procedure
+    .input(
+      z.object({
+        version: z.string()
+      })
+    )
+    .query(async (req) => {
+      open(`https://github.com/bscotch/stitch/issues/new?title=Desktop%20issue&labels=desktop&body=Version:%20${req.input.version}`)
+    }),
   openPath: t.procedure
     .input(
       z.object({

--- a/packages/desktop-ui/src/routes/projects/Settings.svelte
+++ b/packages/desktop-ui/src/routes/projects/Settings.svelte
@@ -22,6 +22,10 @@
     await trpc.openPath.query({ name: 'stitchDesktopConfig' });
   }
 
+  async function openIssues() {
+    await trpc.openIssues.query({ version: stitchVersion });
+  }
+
   async function loadGameMakerPaths() {
     const knownPaths = await trpc.listGameMakerPaths.query();
     knownPaths.sort((a, b) => a.name.localeCompare(b.name));
@@ -63,6 +67,7 @@
         {stitchVersion}
       </span>
     </h2>
+    <p>Have an issue? <a role="button" on:click={openIssues}>Click here.</a></p>
     <p />
     <p>
       Stitch currently stores its settings in a


### PR DESCRIPTION
This should help address [https://github.com/bscotch/stitch/issues/40](this issue). Adds a link in the settings that opens directly to the new issue page, prefilled with the app version.

Feature:
![Screenshot 2023-04-29 200855](https://user-images.githubusercontent.com/13367277/235333657-64c210bb-95ca-4a40-849c-84fdf4b75b77.png)

Destination:
![Screenshot 2023-04-29 200926](https://user-images.githubusercontent.com/13367277/235333662-1e7be671-21c8-4ebf-8d11-12904a036cf1.png)
