### PR TITLE
Custom Object Event Labels

### DIFF
--- a/packages/vscode/src/tree.items.mts
+++ b/packages/vscode/src/tree.items.mts
@@ -9,6 +9,7 @@ import vscode from 'vscode';
 import { getAssetIcon } from './icons.mjs';
 import { StitchTreeItemBase, setEventIcon } from './tree.base.mjs';
 import { GameMakerFolder } from './tree.folder.mjs';
+import * as fs from "fs";
 
 // ICONS: See https://code.visualstudio.com/api/references/icons-in-labels#icon-listing
 
@@ -171,7 +172,21 @@ export class TreeCode extends StitchTreeItemBase<'code'> {
 
     // Ensure that the tree label is human-friendly.
     this.label = getEventFromFilename(this.uri.fsPath);
+
+    // If no label try to use the @description
+    if (!this.label) {
+      const key = '/// @description';
+      let firstLine = this.getFirstLine(this.uri.fsPath);
+      this.label = firstLine.toLowerCase().includes(key) ?
+        firstLine.replace(key, '').trim() :
+        '';
+    }
   }
+
+  private getFirstLine(filePath:string) {
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
+      return (fileContent.match(/(^.*)/) || [])[1] || '';
+  } 
 
   get uri() {
     return vscode.Uri.file(this.code.path.absolute);


### PR DESCRIPTION
After some time using this extension I felt it would be nice to allow a custom label as a fallback for any object event label that fails to generate.

In this case, when the label fails to generate from the file name, I have used `fs` to read the first line of the file looking for `/// @description`. The description annotation is replaced with an empty string which leaves the file description as the label. An empty string is a fallback to this resuming default behavior.

Current version:
![image](https://github.com/bscotch/stitch/assets/40923272/e7031e47-f60b-43b0-a9a6-748101014591)

Patched version:
![image](https://github.com/bscotch/stitch/assets/40923272/9d41b2ea-f6c7-475e-8e50-76e07080db2e)

Example file contents:
```gml
/// @description Test

show_debug_message("Hello");
```

Sorry to not open an issue first, I dug into the code this morning and found the required change was relatively straightforward. It did not take much time. Thanks for the consideration and all of your work on this extension. I really prefer it over the default editor. 🍻