### PR TITLE
chore(core): replace commander and ts-command-line-args with cli-forge

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
   "types": "dist/index.d.ts",
   "bin": "./stitch.mjs",
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build tsconfig.json",
     "clean": "rimraf build dist *.tsbuildinfo **/*.tsbuildinfo",
     "test": "mocha --config ../../config/.mocharc.cjs --parallel=false --timeout=30000",
     "test:dev": "mocha --config ../../config/.mocharc.cjs --forbid-only=false --parallel=false --timeout=9999999999",
@@ -68,6 +68,7 @@
     "archiver": "6.0.1",
     "chalk": "5.3.0",
     "change-case": "5.1.2",
+    "cli-forge": "0.8.0",
     "commander": "11.1.0",
     "debug": "4.3.4",
     "fs-extra": "11.1.1",

--- a/packages/core/src/cli/lib/addDebugOption.ts
+++ b/packages/core/src/cli/lib/addDebugOption.ts
@@ -1,16 +1,17 @@
-import type { Command } from 'commander';
 import { debug } from '../../utility/log.js';
+import { makeComposableBuilder } from 'cli-forge';
 
-export function addDebugOptions(cli: Command) {
-  return cli
-    .option(
-      '--debug',
-      'Run in debug mode, which writes more logs to help triangulate bugs.',
-    )
-    .action(function (options) {
-      if (options.debug) {
+export const addDebugOptions = makeComposableBuilder((cli) =>
+  cli
+    .option('debug', {
+      type: 'boolean',
+      description:
+        'Run in debug mode, which writes more logs to help triangulate bugs.',
+    })
+    .middleware((args) => {
+      if (args.debug) {
         process.env.DEBUG = 'true';
         debug('Running in debug mode');
       }
-    });
-}
+    }),
+);

--- a/packages/core/src/cli/lib/cli-options.ts
+++ b/packages/core/src/cli/lib/cli-options.ts
@@ -1,26 +1,40 @@
 import { oneline } from '@bscotch/utility';
+import { makeComposableBuilder } from 'cli-forge';
 
-export default {
-  force: [
-    '-f --force',
-    oneline`
+export const force = makeComposableBuilder((argv) =>
+  argv.option('force', {
+    type: 'boolean',
+    alias: ['f'],
+    description: oneline`
       Bypass safety checks, including the normal requirement that the project be
       in a clean git state. Only use this option if you know what you're doing.
     `,
-  ],
-  targetProject: [
-    '-t --target-project <path>',
-    oneline`
+  }),
+);
+export const targetProject = makeComposableBuilder((argv) =>
+  argv.option('targetProject', {
+    type: 'string',
+    alias: ['t'],
+    description: oneline`
       Path to the target GameMaker Studio 2 project.
       If not set, will auto-search the current directory.
     `,
-  ],
-  watch: [
-    '--watch',
-    oneline`
+  }),
+);
+export const watch = makeComposableBuilder((argv) =>
+  argv.option('watch', {
+    type: 'boolean',
+    alias: ['w'],
+    description: oneline`
       Run the command with a watcher, so that it will re-run
       any time there is a change to the source files that might
       warrant a re-run.
     `,
-  ],
-} as const;
+  }),
+);
+
+export default {
+  force,
+  targetProject,
+  watch,
+};

--- a/packages/core/src/cli/lib/params.global.ts
+++ b/packages/core/src/cli/lib/params.global.ts
@@ -1,54 +1,50 @@
 import { oneline } from '@bscotch/utility';
-import type { ArgumentConfig } from 'ts-command-line-args';
-import type {
-  StitchCliGlobalParams,
-  StitchCliTargetParams,
-} from './params.types.js';
+import { makeComposableBuilder } from 'cli-forge';
 
 const globalParamsGroup = 'General Options';
 
-export const targetProjectParam: ArgumentConfig<{ targetProject?: string }> = {
-  targetProject: {
-    alias: 't',
-    type: String,
-    optional: true,
-    defaultValue: process.cwd(),
+export const withTargetProjectParam = makeComposableBuilder((args) =>
+  args.option('targetProject', {
+    alias: ['t'],
+    type: 'string',
+    default: {
+      value: process.cwd(),
+      description: 'Current directory',
+    },
     description: oneline`
-      Path to the target GameMaker Studio 2 project.
-      If not set, will auto-search the current directory.
-    `,
+        Path to the target GameMaker Studio 2 project.
+        If not set, will auto-search the current directory.
+      `,
     group: globalParamsGroup,
-  },
-};
+  }),
+);
 
-export const targetParams: ArgumentConfig<StitchCliTargetParams> = {
-  ...targetProjectParam,
-  force: {
-    alias: 'f',
-    type: Boolean,
-    optional: true,
-    description: oneline`
-      Bypass safety checks, including the normal requirement that the project be
-      in a clean git state. Only use this option if you know what you're doing.
-    `,
-    group: globalParamsGroup,
-  },
-  readOnly: {
-    type: Boolean,
-    optional: true,
-    description: oneline`
-      Prevent any file-writes from occurring. Useful to prevent
-      automatic fixes from being applied and for testing purposes.
-      Commands may behave unexpectedly when this option is enabled.
-    `,
-    group: globalParamsGroup,
-  },
-};
+export const withTargetParams = makeComposableBuilder((args) =>
+  withTargetProjectParam(args)
+    .option('force', {
+      alias: ['f'],
+      type: 'boolean',
+      description: oneline`
+        Bypass safety checks, including the normal requirement that the project be
+        in a clean git state. Only use this option if you know what you're doing.
+      `,
+      group: globalParamsGroup,
+    })
+    .option('readOnly', {
+      type: 'boolean',
+      description: oneline`
+        Prevent any file-writes from occurring. Useful to prevent
+        automatic fixes from being applied and for testing purposes.
+        Commands may behave unexpectedly when this option is enabled.
+      `,
+      group: globalParamsGroup,
+    }),
+);
 
-export const watchParam: ArgumentConfig<{ watch?: boolean }> = {
-  watch: {
-    alias: 'w',
-    type: Boolean,
+export const withWatchParam = makeComposableBuilder((args) =>
+  args.option('watch', {
+    alias: ['w'],
+    type: 'boolean',
     optional: true,
     description: oneline`
       Run the command with a watcher, so that it will re-run
@@ -56,21 +52,21 @@ export const watchParam: ArgumentConfig<{ watch?: boolean }> = {
       warrant a re-run.
     `,
     group: globalParamsGroup,
-  },
-};
+  }),
+);
 
-export const globalParams: ArgumentConfig<StitchCliGlobalParams> = {
-  help: {
-    alias: 'h',
-    type: Boolean,
-    optional: true,
-    group: globalParamsGroup,
-  },
-  debug: {
-    alias: 'd',
-    type: Boolean,
-    optional: true,
-    defaultValue: !!process.env.DEBUG,
-    group: globalParamsGroup,
-  },
-};
+export const withGlobalParams = makeComposableBuilder((args) =>
+  args
+    .option('help', {
+      alias: ['h'],
+      type: 'boolean',
+      description: 'Show help',
+      group: globalParamsGroup,
+    })
+    .option('debug', {
+      alias: ['d'],
+      type: 'boolean',
+      description: 'Run in debug mode',
+      group: globalParamsGroup,
+    }),
+);

--- a/packages/core/src/cli/lib/params.merge.ts
+++ b/packages/core/src/cli/lib/params.merge.ts
@@ -1,33 +1,28 @@
 import { oneline } from '@bscotch/utility';
-import { ArgumentConfig } from 'ts-command-line-args';
 import {
   Gms2ResourceArray,
   Gms2ResourceType,
 } from '../../lib/components/Gms2ResourceArray.js';
-import {
-  ClobberAction,
-  StitchMergerOptions,
-} from '../../lib/StitchProjectMerger.js';
 import { assert } from '../../utility/errors.js';
-import type { Gms2MergeCliSourceOptions } from './merge.js';
 import { parseGitHubString } from './parseGitHubString.js';
+import { makeComposableBuilder } from 'cli-forge';
 
 const mergeSourceGroup = 'Merge Source';
 
-export const mergeSourceParams: ArgumentConfig<Gms2MergeCliSourceOptions> = {
-  source: {
-    alias: 's',
-    type: String,
-    optional: true,
-    group: mergeSourceGroup,
-    description: 'Local path to the source GameMaker Studio 2 project.',
-  },
-  sourceGithub: {
-    alias: 'g',
-    type: parseGitHubString,
-    optional: true,
-    group: mergeSourceGroup,
-    description: oneline`
+export const withMergeSourceParams = makeComposableBuilder((argv) =>
+  argv
+    .option('source', {
+      alias: ['s'],
+      type: 'string',
+      group: mergeSourceGroup,
+      description: 'Local path to the source GameMaker Studio 2 project.',
+    })
+    .option('sourceGithub', {
+      alias: ['g'],
+      type: 'string',
+      coerce: parseGitHubString,
+      group: mergeSourceGroup,
+      description: oneline`
       Repo owner and name for a Gamemaker Studio 2 project
       on GitHub in format \`owner/repo@revision\`.
       The revision suffix is optional, and
@@ -41,50 +36,47 @@ export const mergeSourceParams: ArgumentConfig<Gms2MergeCliSourceOptions> = {
       tagPattern is provided, Stitch uses HEAD. To provide
       credentials for private GitHub repos, see the README.
     `,
-  },
-  sourceUrl: {
-    alias: 'u',
-    type: String,
-    optional: true,
-    group: mergeSourceGroup,
-    description: 'URL to a zipped GameMaker Studio 2 project.',
-  },
-};
+    })
+    .option('sourceUrl', {
+      alias: ['u'],
+      type: 'string',
+      group: mergeSourceGroup,
+      description: 'URL to a zipped GameMaker Studio 2 project.',
+    }),
+);
 
 const mergeOptionsGroup = 'Merge Options';
 
-export const mergeOptionsParams: ArgumentConfig<StitchMergerOptions> = {
-  ifFolderMatches: {
-    type: String,
-    optional: true,
-    multiple: true,
-    group: mergeOptionsGroup,
-    description: oneline`
+export const withMergeOptionsParams = makeComposableBuilder((argv) =>
+  argv
+    .option('ifFolderMatches', {
+      type: 'array',
+      items: 'string',
+      group: mergeOptionsGroup,
+      description: oneline`
       List of source folder patterns that, if matched,
       should have all child assets imported (recursive).
       Will be passed to \`new RegExp()\` and tested against
       the parent folder of every source resource.
       Independent from ifNameMatches. Case is ignored.
     `,
-  },
-  ifNameMatches: {
-    type: String,
-    optional: true,
-    multiple: true,
-    group: mergeOptionsGroup,
-    description: oneline`
+    })
+    .option('ifNameMatches', {
+      type: 'array',
+      items: 'string',
+      group: mergeOptionsGroup,
+      description: oneline`
       List of source resource name patterns that, if matched,
       should have all child assets imported (recursive).
       Will be passed to \`new RegExp()\` and tested against
       the name of every source resource.
       Independent from ifFolderMatches. Case is ignored.
     `,
-  },
-  moveConflicting: {
-    type: Boolean,
-    optional: true,
-    group: mergeOptionsGroup,
-    description: oneline`
+    })
+    .option('moveConflicting', {
+      type: 'boolean',
+      group: mergeOptionsGroup,
+      description: oneline`
       The target project may have assets matching your
       merge pattern, but that aren't in the source.
       By default these are left alone, which can create some
@@ -95,19 +87,13 @@ export const mergeOptionsParams: ArgumentConfig<StitchMergerOptions> = {
       this flag if your source and target projects are using
       unique folder names for their assets.
     `,
-  },
-  onClobber: {
-    type: (input: string) => {
-      assert(
-        ['error', 'skip', 'overwrite'].includes(input),
-        'Invalid onClobber value',
-      );
-      return input as ClobberAction;
-    },
-    optional: true,
-    defaultValue: 'overwrite',
-    group: mergeOptionsGroup,
-    description: oneline`
+    })
+    .option('onClobber', {
+      type: 'string',
+      defaultValue: 'overwrite',
+      group: mergeOptionsGroup,
+      choices: ['overwrite', 'skip', 'error'],
+      description: oneline`
       If source assets match target assets by name,
       but those matching assets are not matched by the merge
       options, it's possible that the two assets are not
@@ -115,44 +101,44 @@ export const mergeOptionsParams: ArgumentConfig<StitchMergerOptions> = {
       You can change the behavior to instead skip importing
       those assets (keeping the target version) or throw an error.
     `,
-  },
-  skipDependencyCheck: {
-    type: Boolean,
-    optional: true,
-    group: mergeOptionsGroup,
-    description: oneline`
+    })
+    .option('skipDependencyCheck', {
+      type: 'boolean',
+      group: mergeOptionsGroup,
+      description: oneline`
       If an object in your source has dependencies
       (parent objects or sprites) that are *not* being merged,
       import will be blocked. This prevents accidentally importing
       broken assets. If you know that those missing dependencies
       will be found in the target project, you can skip this check.
     `,
-  },
-  skipIncludedFiles: {
-    type: Boolean,
-    optional: true,
-    group: mergeOptionsGroup,
-    description: oneline`
+    })
+    .option('skipIncludedFiles', {
+      type: 'boolean',
+      group: mergeOptionsGroup,
+      description: oneline`
       By default, "Included Files" are also merged if
       they match filters. These can be skipped.
     `,
-  },
-  types: {
-    type: (input: string) => {
-      assert(
-        Gms2ResourceArray.resourceTypeNames.includes(input as any),
-        `Invalid resource type: ${input}`,
-      );
-      return input as Gms2ResourceType;
-    },
-    optional: true,
-    multiple: true,
-    group: mergeOptionsGroup,
-    description: oneline`
+    })
+    .option('types', {
+      type: 'array',
+      items: 'string',
+      group: mergeOptionsGroup,
+      description: oneline`
       All resource types are included by default. You can
       optionally change to a whitelist pattern and only
       include specific types. Types are:
       ${Object.keys(Gms2ResourceArray.resourceClassMap).join(', ')}
     `,
-  },
-};
+      coerce: (inputs: string[]) => {
+        return inputs.map((input) => {
+          assert(
+            Gms2ResourceArray.resourceTypeNames.includes(input as any),
+            `Invalid resource type: ${input}`,
+          );
+          return input as Gms2ResourceType;
+        });
+      },
+    }),
+);

--- a/packages/core/src/cli/lib/params.ts
+++ b/packages/core/src/cli/lib/params.ts
@@ -1,9 +1,5 @@
-import { keysOf } from '@bscotch/utility';
-import { ArgumentConfig, parse as parseArgs } from 'ts-command-line-args';
 import { StitchProject } from '../../index.js';
-import { assert } from '../../utility/errors.js';
-import { globalParams } from './params.global.js';
-import { StitchCliParams, StitchCliTargetParams } from './params.types.js';
+import { StitchCliTargetParams } from './params.types.js';
 
 export * from './params.global.js';
 export * from './params.merge.js';
@@ -16,42 +12,5 @@ export async function loadProjectFromArgs<T extends StitchCliTargetParams>(
     projectPath: options.targetProject,
     dangerouslyAllowDirtyWorkingDir: options.force,
     readOnly: options.readOnly,
-  });
-}
-
-export function parseStitchArgs<T extends Record<string, any>>(
-  args: ArgumentConfig<T>,
-  info: {
-    title: string;
-    description: string;
-  },
-): StitchCliParams<T> {
-  const argsConfig: ArgumentConfig<StitchCliParams<T>> = {
-    ...args,
-    ...globalParams,
-  };
-  const argNames = keysOf(argsConfig);
-  const groups: string[] = argNames.map((name) => {
-    // @ts-expect-error
-    const { group } = argsConfig[name];
-    assert(
-      group,
-      `Argument definition for ${name as any} does not have a group.`,
-    );
-    return group;
-  });
-  return parseArgs<StitchCliParams<T>>(argsConfig, {
-    // @ts-expect-error
-    helpArg: 'help',
-    headerContentSections: [
-      {
-        header: info.title,
-        content: info.description,
-      },
-    ],
-    optionSections: [...new Set(groups)].map((groupName) => ({
-      group: groupName,
-      header: groupName,
-    })),
   });
 }

--- a/packages/core/src/cli/stitch-add-files.ts
+++ b/packages/core/src/cli/stitch-add-files.ts
@@ -1,35 +1,41 @@
 #!/usr/bin/env node
 import { oneline, undent } from '@bscotch/utility';
-import { program as cli } from 'commander';
-import { ImportBaseOptions } from './lib/add-base-options.js';
+import { cli, chain } from 'cli-forge';
 import importFiles from './lib/add-files.js';
 import { addDebugOptions } from './lib/addDebugOption.js';
-import options from './lib/cli-options.js';
+import * as options from './lib/cli-options.js';
 import { runOrWatch } from './watch.js';
 
-cli
-  .description(
-    undent`
+export const addFilesCommand = cli('files', {
+  description: undent`
   Create/update included file assets from a file or a path.
   If the asset does not already exists in the target project, it will be placed in the "NEW" folder.
   Otherwise, the asset will be replaced by the source asset.`,
-  )
-  .requiredOption(
-    '--source <path>',
-    oneline`
-    Path to the file or the folder containing the files to import.
-  `,
-  )
-  .option(
-    '--extensions <extensions...>',
-    oneline`
-    Only allow certain extensions to be imported. 
-    If not set, Will attempt to import all files.
-  `,
-  )
-  .option(...options.targetProject)
-  .option(...options.force);
-addDebugOptions(cli).parse(process.argv);
 
-const opts = cli.opts() as ImportBaseOptions & { extensions?: string };
-runOrWatch(opts, () => importFiles(opts), opts.source, opts.extensions);
+  builder: (argv) =>
+    chain(argv, options.force, options.targetProject, addDebugOptions)
+      .option('extensions', {
+        type: 'array',
+        items: 'string',
+        description: oneline`
+        Only allow certain extensions to be imported. 
+        If not set, Will attempt to import all files.
+      `,
+      })
+      .option('source', {
+        type: 'string',
+        description: oneline`
+        Path to the file or the folder containing the files to import.
+      `,
+      }),
+  handler: (argv) => {
+    runOrWatch(
+      // argv doesn't have watch, so we are casting it here... I don't love that,
+      // but I think adding watch wouldn't make sense here either.
+      argv as { watch?: boolean },
+      () => importFiles(argv),
+      argv.source,
+      argv.extensions,
+    );
+  },
+});

--- a/packages/core/src/cli/stitch-add-sounds.ts
+++ b/packages/core/src/cli/stitch-add-sounds.ts
@@ -1,44 +1,49 @@
 #!/usr/bin/env node
 import { oneline, undent } from '@bscotch/utility';
-import { program as cli } from 'commander';
 import { StitchProject } from '../lib/StitchProject.js';
-import { ImportBaseOptions } from './lib/add-base-options.js';
 import importSounds from './lib/add-sounds.js';
 import { addDebugOptions } from './lib/addDebugOption.js';
-import options from './lib/cli-options.js';
+import * as options from './lib/cli-options.js';
 import { runOrWatch } from './watch.js';
+import { cli, chain } from 'cli-forge';
 
-cli
-  .description(
-    undent`
+export const addSoundsCommand = cli('sounds', {
+  description: undent`
     Create/update sound assets from a file or a path.
     If the asset does not already exists in the target project, it will be placed in the "NEW" folder.
     Otherwise, the asset will be replaced by the source asset.`,
-  )
-  .requiredOption(
-    '--source <path>',
-    oneline`
-    Path to the sound file or the folder containing the sounds files.
-  `,
-  )
-  .option(
-    '--extensions <extensions...>',
-    oneline`
-    input one or more of the supported extensions: mp3, wav, ogg, wma. 
-    If not set, Will attempt to import all supported extensions.
-  `,
-  )
-  .option(...options.targetProject)
-  .option(...options.force)
-  .option(...options.watch);
-addDebugOptions(cli).parse(process.argv);
-
-const opts = cli.opts() as ImportBaseOptions & { extensions?: string };
-runOrWatch(
-  opts,
-  () => importSounds(opts),
-  opts.source,
-  opts.extensions
-    ? opts.extensions.split(',')
-    : StitchProject.supportedSoundFileExtensions,
-);
+  builder: (argv) =>
+    chain(
+      argv,
+      addDebugOptions,
+      options.force,
+      options.targetProject,
+      options.watch,
+    )
+      .option('source', {
+        type: 'string',
+        required: true,
+        description: oneline`
+        Path to the sound file or the folder containing the sounds files.
+      `,
+      })
+      .option('extensions', {
+        type: 'array',
+        items: 'string',
+        description: oneline`
+        input one or more of the supported extensions: mp3, wav, ogg, wma. 
+        If not set, Will attempt to import all supported extensions.
+      `,
+      }),
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  handler: (argv) => {
+    runOrWatch(
+      argv,
+      () => importSounds(argv),
+      argv.source,
+      argv.extensions
+        ? argv.extensions
+        : StitchProject.supportedSoundFileExtensions,
+    );
+  },
+});

--- a/packages/core/src/cli/stitch-add-sprites.ts
+++ b/packages/core/src/cli/stitch-add-sprites.ts
@@ -1,16 +1,14 @@
 #!/usr/bin/env node
 import { oneline, undent } from '@bscotch/utility';
-import { program } from 'commander';
-import { SpriteImportOptions } from '../lib/StitchProject.js';
-import { ImportBaseOptions } from './lib/add-base-options.js';
+
 import importSprites from './lib/add-sprites.js';
 import { addDebugOptions } from './lib/addDebugOption.js';
 import options from './lib/cli-options.js';
 import { runOrWatch } from './watch.js';
+import { cli, chain } from 'cli-forge';
 
-program
-  .description(
-    undent`
+export const addSpritesCommand = cli('sprites', {
+  description: undent`
     Create/update sprite assets collection of images.
     A 'sprite' source is any folder whose immediate children
     are all PNGs with identical dimensions. Sprites can be
@@ -18,66 +16,66 @@ program
     If the asset does not already exists in the target project,
     it will be placed in the "NEW" folder.
     Otherwise, the asset will be replaced by the source asset.`,
-  )
-  .requiredOption(
-    '--source <path>',
-    oneline`
-    Path to the sprite folder or root folder containing multiple sprites.
-  `,
-  )
-  .option(...options.targetProject)
-  .option(
-    '--prefix <prefix>',
-    oneline`
-    Prefix the source names when creating/updateing sprites
-    based on the source folders. Prefixing is performed after
-    casing, so it will be used as-is.
-  `,
-  )
-  .option(
-    '--postfix <postfix>',
-    oneline`
-    Postfix the source names when creating/updateing sprites
-    based on the source folders. Postfixing is performed after
-    casing, so it will be used as-is.
-  `,
-  )
-  .option(
-    '--case <keep|snake|camel|pascal>',
-    oneline`
-    Normalize the casing upon import. This ensures consistent
-    casing of assets even if the source is either inconsistent
-    or uses a different casing than intended in the game project.
-  `,
-    'keep',
-  )
-  .option(
-    '--flatten',
-    oneline`
-    By default each sprite resource is named by its final folder
-    (e.g. a sprite at 'root/my/sprite' will be called 'sprite').
-    Use this flag to convert the entire post-root path to the
-    sprite's name (e.g. 'root/my/sprite' will be called 'my_sprite'
-    if using snake case).
-  `,
-  )
-  .option(
-    '--exclude <pattern>',
-    oneline`
-    The provided pattern will be converted to a RegEx using
-    JavaScript's \`new RegExp()\` function. Any sprites whose
-    *original* names match the pattern will not be imported.
-  `,
-  )
-  .option(...options.force)
-  .option(...options.watch);
-addDebugOptions(program).parse(process.argv);
-
-const opts = program.opts();
-
-runOrWatch(
-  opts,
-  () => importSprites(opts as ImportBaseOptions & SpriteImportOptions),
-  opts.source,
-  'png',
-);
+  builder: (argv) =>
+    chain(
+      argv,
+      addDebugOptions,
+      options.force,
+      options.targetProject,
+      options.watch,
+    )
+      .option('source', {
+        type: 'string',
+        required: true,
+        description: oneline`
+        Path to the sprite folder or root folder containing multiple sprites.
+      `,
+      })
+      .option('prefix', {
+        type: 'string',
+        description: oneline`
+        Prefix the source names when creating/updateing sprites
+        based on the source folders. Prefixing is performed after
+        casing, so it will be used as-is.
+      `,
+      })
+      .option('postfix', {
+        type: 'string',
+        description: oneline`
+        Postfix the source names when creating/updateing sprites
+        based on the source folders. Postfixing is performed after
+        casing, so it will be used as-is.
+      `,
+      })
+      .option('case', {
+        type: 'string',
+        description: oneline`
+        Normalize the casing upon import. This ensures consistent
+        casing of assets even if the source is either inconsistent
+        or uses a different casing than intended in the game project.
+      `,
+        default: 'keep',
+        choices: ['keep', 'snake', 'camel', 'pascal'],
+      })
+      .option('flatten', {
+        type: 'boolean',
+        description: oneline`
+        By default each sprite resource is named by its final folder
+        (e.g. a sprite at 'root/my/sprite' will be called 'sprite').
+        Use this flag to convert the entire post-root path to the
+        sprite's name (e.g. 'root/my/sprite' will be called 'my_sprite'
+        if using snake case).
+      `,
+      })
+      .option('exclude', {
+        type: 'string',
+        description: oneline`
+        The provided pattern will be converted to a RegEx using
+        JavaScript's \`new RegExp()\` function. Any sprites whose
+        *original* names match the pattern will not be imported.
+      `,
+      }),
+  handler: (opts) => {
+    runOrWatch(opts, () => importSprites(opts), opts.source, 'png');
+  },
+});

--- a/packages/core/src/cli/stitch-add.ts
+++ b/packages/core/src/cli/stitch-add.ts
@@ -1,15 +1,13 @@
 #!/usr/bin/env node
-import { program as cli } from 'commander';
+import { cli } from 'cli-forge';
 
-cli
-  .description('Create GameMaker Studio 2 resources.')
-  .command(
-    'sounds',
-    'Create sound assets from a file or a path to a target project.',
-  )
-  .command('sprites', 'Create sprite assets from a collection of images.')
-  .command(
-    'files',
-    'Create included files assets from a file or a path to a target project.',
-  )
-  .parse(process.argv);
+import { addFilesCommand } from './stitch-add-files.js';
+import { addSoundsCommand } from './stitch-add-sounds.js';
+import { addSpritesCommand } from './stitch-add-sprites.js';
+
+export const addCommand = cli('add', {
+  description:
+    'Create assets (e.g. sprites) using external resources (e.g. images).',
+  builder: (cli) =>
+    cli.commands(addFilesCommand, addSoundsCommand, addSpritesCommand),
+});

--- a/packages/core/src/cli/stitch-archive.ts
+++ b/packages/core/src/cli/stitch-archive.ts
@@ -1,26 +1,20 @@
 #!/usr/bin/env node
+import { cli, chain } from 'cli-forge';
 import {
-  globalParams,
   loadProjectFromArgs,
-  parseStitchArgs,
-  targetProjectParam,
+  withGlobalParams,
+  withTargetProjectParam,
 } from './lib/params.js';
 
-const args = parseStitchArgs(
-  {
-    ...globalParams,
-    ...targetProjectParam,
+export const archiveCommand = cli('archive', {
+  description: `Create a .yyz archive of a GameMaker project.`,
+  builder: (cli) => chain(cli, withGlobalParams, withTargetProjectParam),
+  handler: async (args) => {
+    // Note: Adding an issue template doesn't have any impact
+    // on project state, since it could be submitted at some
+    // other time, so we can always bypass the dirty working dir
+    // check.
+    const targetProject = await loadProjectFromArgs({ ...args, force: true });
+    await targetProject.exportYyz();
   },
-  {
-    title: 'Archive',
-    description: `Create a .yyz archive of a GameMaker project. This is useful for sharing a project with others, including for GameMaker support tickets.`,
-  },
-);
-
-// Note: Adding an issue template doesn't have any impact
-// on project state, since it could be submitted at some
-// other time, so we can always bypass the dirty working dir
-// check.
-const targetProject = await loadProjectFromArgs({ ...args, force: true });
-
-await targetProject.exportYyz();
+});

--- a/packages/core/src/cli/stitch-debork.ts
+++ b/packages/core/src/cli/stitch-debork.ts
@@ -1,21 +1,23 @@
 #!/usr/bin/env node
-import { program as cli } from 'commander';
+import { cli, chain } from 'cli-forge';
 import { StitchProject } from '../lib/StitchProject.js';
 import { addDebugOptions } from './lib/addDebugOption.js';
 import options from './lib/cli-options.js';
+import { oneline } from '@bscotch/utility';
 
-cli
-  .description(
-    'Fix and normalize common issues in a GameMaker Studio 2.3+ Project.',
-  )
-  .option(...options.targetProject)
-  .option(...options.force);
-addDebugOptions(cli).parse(process.argv);
-
-const opts = cli.opts();
-(
-  await StitchProject.load({
-    projectPath: opts.targetProject,
-    dangerouslyAllowDirtyWorkingDir: opts.force,
-  })
-).save();
+export const deborkCommand = cli('debork', {
+  description: oneline`
+  Run Stitch on the project without making any changes,
+  which will clean up some common issues and normalize the file content.
+`,
+  builder: (cli) =>
+    chain(cli, options.targetProject, options.force, addDebugOptions),
+  handler: async (args) => {
+    (
+      await StitchProject.load({
+        projectPath: args.targetProject,
+        dangerouslyAllowDirtyWorkingDir: args.force,
+      })
+    ).save();
+  },
+});

--- a/packages/core/src/cli/stitch-issues-create.ts
+++ b/packages/core/src/cli/stitch-issues-create.ts
@@ -15,129 +15,137 @@ import {
   listLocalProjectChoices,
   openGameMakerIssue,
 } from './lib/issuesLib.js';
+import { cli } from 'cli-forge';
 
-const answers = await inquirer.prompt<
-  {
-    name?: string;
-    allPlatforms?: boolean;
-    template: string;
-    newTemplate?: string;
-  } & GameMakerIssueForm
->([
-  {
-    type: 'input',
-    name: 'summary',
-    message: 'Title for the issue (short, precise, and descriptive)',
-    validate(value: string) {
-      return value?.length < 128
-        ? true
-        : 'Title must be less than 128 characters';
-    },
-  },
-  {
-    type: 'input',
-    name: 'description',
-    message:
-      'Fully describe the issue, including information about replication and context.',
-  },
-  {
-    type: 'list',
-    name: 'type',
-    message: 'What type of issue is this?',
-    choices: Object.entries(issueTypes).map((entry) => ({
-      name: entry[1],
-      value: entry[0],
-    })),
-  },
-  {
-    type: 'checkbox',
-    name: 'affected',
-    message: 'What features are impacted?',
-
-    choices(answers) {
-      return issueAffectedAreaOptions[answers.type];
-    },
-  },
-  {
-    type: 'checkbox',
-    name: 'platforms',
-    when(answers) {
-      return !answers.allPlatforms;
-    },
-    message: 'Which platforms are affected?',
-    choices: issueAffectedPlatforms,
-    validate(value: string[]) {
-      return value.length > 0 ? true : 'You must select at least one platform';
-    },
-    default: issueAffectedPlatforms,
-  },
-  {
-    type: 'list',
-    name: 'template',
-    message: 'Choose a template to clone for this issue.',
-    async choices() {
-      const templates = [
-        new inquirer.Separator('\n--- Templates ---'),
-        // Add the default template, shipped with the package
-        {
-          name: "🚀 Use Stitch's template",
-          value: Gms2Project.defaultProjectTemplatePath,
+export const createCommand = cli('create', {
+  description: 'Create a new GameMaker issue.',
+  handler: async () => {
+    const answers = await inquirer.prompt<
+      {
+        name?: string;
+        allPlatforms?: boolean;
+        template: string;
+        newTemplate?: string;
+      } & GameMakerIssueForm
+    >([
+      {
+        type: 'input',
+        name: 'summary',
+        message: 'Title for the issue (short, precise, and descriptive)',
+        validate(value: string) {
+          return value?.length < 128
+            ? true
+            : 'Title must be less than 128 characters';
         },
-        // Add an option to specify a custom template
-        {
-          name: '🆕 Use a new template',
-          value: '',
+      },
+      {
+        type: 'input',
+        name: 'description',
+        message:
+          'Fully describe the issue, including information about replication and context.',
+      },
+      {
+        type: 'list',
+        name: 'type',
+        message: 'What type of issue is this?',
+        choices: Object.entries(issueTypes).map((entry) => ({
+          name: entry[1],
+          value: entry[0],
+        })),
+      },
+      {
+        type: 'checkbox',
+        name: 'affected',
+        message: 'What features are impacted?',
+
+        choices(answers) {
+          return issueAffectedAreaOptions[answers.type];
         },
-        new inquirer.Separator('\n--- Existing Issues ---'),
-        ...(await listIssueProjectChoices()),
-        new inquirer.Separator('\n--- Local Projects ---'),
-        ...(await listLocalProjectChoices()),
-      ];
-      return templates;
-    },
-  },
-  {
-    type: 'input',
-    name: 'newTemplate',
-    message: 'Enter the path to the template to use',
-    when(answers) {
-      return answers.template === '';
-    },
-    validate(value: string) {
-      const templatePath = new Pathy(value);
-      return templatePath.existsSync() ? true : 'Template does not exist';
-    },
-  },
-  {
-    type: 'input',
-    name: 'name',
-    message: 'Name the new GameMaker project:',
-    async validate(name: string) {
-      // Make sure it won't clobber
-      if (name.length === 0) {
-        return 'You must enter a name!';
-      }
-      return (await GameMakerIssue.issuesDirectory
-        .join(kebabCase(name))
-        .isEmptyDirectory({ allowNotFound: true }))
-        ? true
-        : 'An issue with that name already exists';
-    },
-  },
-]);
+      },
+      {
+        type: 'checkbox',
+        name: 'platforms',
+        when(answers) {
+          return !answers.allPlatforms;
+        },
+        message: 'Which platforms are affected?',
+        choices: issueAffectedPlatforms,
+        validate(value: string[]) {
+          return value.length > 0
+            ? true
+            : 'You must select at least one platform';
+        },
+        default: issueAffectedPlatforms,
+      },
+      {
+        type: 'list',
+        name: 'template',
+        message: 'Choose a template to clone for this issue.',
+        async choices() {
+          const templates = [
+            new inquirer.Separator('\n--- Templates ---'),
+            // Add the default template, shipped with the package
+            {
+              name: "🚀 Use Stitch's template",
+              value: Gms2Project.defaultProjectTemplatePath,
+            },
+            // Add an option to specify a custom template
+            {
+              name: '🆕 Use a new template',
+              value: '',
+            },
+            new inquirer.Separator('\n--- Existing Issues ---'),
+            ...(await listIssueProjectChoices()),
+            new inquirer.Separator('\n--- Local Projects ---'),
+            ...(await listLocalProjectChoices()),
+          ];
+          return templates;
+        },
+      },
+      {
+        type: 'input',
+        name: 'newTemplate',
+        message: 'Enter the path to the template to use',
+        when(answers) {
+          return answers.template === '';
+        },
+        validate(value: string) {
+          const templatePath = new Pathy(value);
+          return templatePath.existsSync() ? true : 'Template does not exist';
+        },
+      },
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Name the new GameMaker project:',
+        async validate(name: string) {
+          // Make sure it won't clobber
+          if (name.length === 0) {
+            return 'You must enter a name!';
+          }
+          return (await GameMakerIssue.issuesDirectory
+            .join(kebabCase(name))
+            .isEmptyDirectory({ allowNotFound: true }))
+            ? true
+            : 'An issue with that name already exists';
+        },
+      },
+    ]);
 
-const issueProject = await Gms2Project.cloneProject({
-  templatePath: (answers.newTemplate || answers.template).toString(),
-  name: answers.name,
-  where: GameMakerIssue.issuesDirectory.absolute,
+    const issueProject = await Gms2Project.cloneProject({
+      templatePath: (answers.newTemplate || answers.template).toString(),
+      name: answers.name,
+      where: GameMakerIssue.issuesDirectory.absolute,
+    });
+
+    await issueProject.issue.updateForm({
+      affected: answers.affected,
+      platforms: answers.platforms,
+      summary: answers.summary,
+      description: answers.description,
+      type: answers.type,
+    });
+
+    await openGameMakerIssue(issueProject);
+  },
 });
-
-await issueProject.issue.updateForm({
-  affected: answers.affected,
-  platforms: answers.platforms,
-  summary: answers.summary,
-  description: answers.description,
-  type: answers.type,
-});
-
-await openGameMakerIssue(issueProject);

--- a/packages/core/src/cli/stitch-issues-submit.ts
+++ b/packages/core/src/cli/stitch-issues-submit.ts
@@ -2,38 +2,46 @@
 import { default as inquirer } from 'inquirer';
 import { StitchProject } from '../index.js';
 import { listIssueProjectChoices, openPaths } from './lib/issuesLib.js';
+import { cli } from 'cli-forge';
 
-const answers = await inquirer.prompt<{
-  targetProject?: string;
-}>([
-  {
-    type: 'list',
-    name: 'targetProject',
-    message: 'Which Issue do you want to submit?',
-    async choices() {
-      return await listIssueProjectChoices();
-    },
+export const submitCommand = cli('submit', {
+  description: 'Submit a GameMaker issue.',
+  handler: async () => {
+    const answers = await inquirer.prompt<{
+      targetProject?: string;
+    }>([
+      {
+        type: 'list',
+        name: 'targetProject',
+        message: 'Which Issue do you want to submit?',
+        async choices() {
+          return await listIssueProjectChoices();
+        },
+      },
+    ]);
+
+    if (!answers.targetProject) {
+      process.exit(0);
+    }
+
+    const issueProject = await StitchProject.load({
+      projectPath: answers.targetProject,
+      dangerouslyAllowDirtyWorkingDir: true,
+      readOnly: true,
+    });
+
+    await issueProject.issue.collectLogs();
+
+    const report = await issueProject.issue.compileReport();
+
+    await openPaths([
+      {
+        path: issueProject.issue.attachmentsDirectory.toString({
+          format: 'win32',
+        }),
+        app: { name: 'explorer' },
+      },
+      report.mailTo,
+    ]);
   },
-]);
-
-if (!answers.targetProject) {
-  process.exit(0);
-}
-
-const issueProject = await StitchProject.load({
-  projectPath: answers.targetProject,
-  dangerouslyAllowDirtyWorkingDir: true,
-  readOnly: true,
 });
-
-await issueProject.issue.collectLogs();
-
-const report = await issueProject.issue.compileReport();
-
-await openPaths([
-  {
-    path: issueProject.issue.attachmentsDirectory.toString({ format: 'win32' }),
-    app: { name: 'explorer' },
-  },
-  report.mailTo,
-]);

--- a/packages/core/src/cli/stitch-issues.ts
+++ b/packages/core/src/cli/stitch-issues.ts
@@ -1,19 +1,13 @@
 #!/usr/bin/env node
 import { prettifyErrorTracing, replaceFilePaths } from '@bscotch/validation';
-import { program as cli } from 'commander';
+import { cli } from 'cli-forge';
+import { createCommand } from './stitch-issues-create.js';
+import { openCommand } from './stitch-issues-open.js';
+import { submitCommand } from './stitch-issues-submit.js';
 
 prettifyErrorTracing({ replaceFilePaths });
 
-// Kick it off
-cli
-  .description('Stitch Issues')
-  .command(
-    'create',
-    'Create an issue template for a bug report to submit to GameMaker.',
-  )
-  .command('open', 'Open files and folders from an existing issue project.')
-  .command(
-    'submit',
-    'For a completed issue project, collect logs and compile a report for submission to GameMaker. (Only works with GameMaker Enterprise.)',
-  )
-  .parse();
+export const issuesCommand = cli('issues', {
+  description: 'Create and manage issues to report to GameMaker.',
+  builder: (cli) => cli.commands(createCommand, openCommand, submitCommand),
+});

--- a/packages/core/src/cli/stitch-lint.ts
+++ b/packages/core/src/cli/stitch-lint.ts
@@ -1,36 +1,38 @@
 #!/usr/bin/env node
-import { program as cli } from 'commander';
+import { cli, chain } from 'cli-forge';
 import { StitchProject } from '../lib/StitchProject.js';
 import cliOptions from './lib/cli-options.js';
 
-cli
-  .description('Generate a lint report.')
-  .option('--suffix', 'Filter out results that do not have the suffix')
-  .option(...cliOptions.targetProject)
-  .option(...cliOptions.force)
-  .parse(process.argv);
+export const lintCommand = cli('lint', {
+  description: 'Generate a lint report for a GameMaker Studio 2 project.',
+  builder: (cli) =>
+    chain(cli, cliOptions.targetProject, cliOptions.force).option('suffix', {
+      description: 'Filter out results that do not have the suffix',
+      type: 'string',
+    }),
+  handler: async (opts) => {
+    const project = await StitchProject.load({
+      projectPath: opts.targetProject,
+      dangerouslyAllowDirtyWorkingDir: opts.force,
+    });
 
-const opts = cli.opts();
-const project = await StitchProject.load({
-  projectPath: opts.targetProject,
-  dangerouslyAllowDirtyWorkingDir: opts.force,
-});
+    const lintResults = project.lint({ versionSuffix: opts.suffix });
+    const { outdatedFunctionReferences, nonreferencedFunctions } =
+      lintResults.getReport();
+    outdatedFunctionReferences?.forEach((outdatedRef) => {
+      console.log(outdatedRef.name);
+      console.log(outdatedRef.location.line);
+      console.log(
+        `Outdated reference at: ${outdatedRef.name}, line ${outdatedRef.location.line}, column ${outdatedRef.location.column}`,
+      );
+    });
 
-const lintResults = project.lint({ versionSuffix: opts.suffix });
-const { outdatedFunctionReferences, nonreferencedFunctions } =
-  lintResults.getReport();
-outdatedFunctionReferences?.forEach((outdatedRef) => {
-  console.log(outdatedRef.name);
-  console.log(outdatedRef.location.line);
-  console.log(
-    `Outdated reference at: ${outdatedRef.name}, line ${outdatedRef.location.line}, column ${outdatedRef.location.column}`,
-  );
-});
-
-nonreferencedFunctions?.forEach((ref) => {
-  console.log(ref.name);
-  console.log(ref.location.line);
-  console.log(
-    `Non-referenced function at: ${ref.name}, line ${ref.location.line}, column ${ref.location.column}`,
-  );
+    nonreferencedFunctions?.forEach((ref) => {
+      console.log(ref.name);
+      console.log(ref.location.line);
+      console.log(
+        `Non-referenced function at: ${ref.name}, line ${ref.location.line}, column ${ref.location.column}`,
+      );
+    });
+  },
 });

--- a/packages/core/src/cli/stitch-merge.ts
+++ b/packages/core/src/cli/stitch-merge.ts
@@ -1,24 +1,24 @@
 #!/usr/bin/env node
-import { Gms2MergeCliOptions, stitchCliMerge } from './lib/merge.js';
+import { cli, chain } from 'cli-forge';
+import { stitchCliMerge } from './lib/merge.js';
 import {
-  globalParams,
-  mergeOptionsParams,
-  mergeSourceParams,
-  parseStitchArgs,
-  targetParams,
+  withGlobalParams,
+  withMergeOptionsParams,
+  withMergeSourceParams,
+  withTargetParams,
 } from './lib/params.js';
 
-export const args = parseStitchArgs<Gms2MergeCliOptions>(
-  {
-    ...globalParams,
-    ...targetParams,
-    ...mergeSourceParams,
-    ...mergeOptionsParams,
+export const mergeCommand = cli('merge', {
+  description: 'Merge two GameMaker Studio 2 projects together.',
+  builder: (cli) =>
+    chain(
+      cli,
+      withGlobalParams,
+      withTargetParams,
+      withMergeSourceParams,
+      withMergeOptionsParams,
+    ),
+  handler: async (args) => {
+    await stitchCliMerge(args);
   },
-  {
-    title: 'Stitch Merge',
-    description: 'Merge assets from one GameMaker project into another.',
-  },
-);
-
-await stitchCliMerge(args);
+});

--- a/packages/core/src/cli/stitch-open.ts
+++ b/packages/core/src/cli/stitch-open.ts
@@ -3,98 +3,71 @@
 import { GameMakerLauncher } from '@bscotch/stitch-launcher';
 import { ok } from 'assert';
 import debug from 'debug';
-import { ArgumentConfig, parse as parseArgs } from 'ts-command-line-args';
 import { StitchProjectStatic } from '../lib/StitchProject.static.js';
 import { loadProjectFromArgs } from './lib/params.js';
+import { cli } from 'cli-forge';
 
-const argsConfig: ArgumentConfig<{
-  project: string;
-  ide?: string;
-  runtime?: string;
-  programFiles?: string;
-  help?: boolean;
-  debug?: boolean;
-}> = {
-  project: {
-    description: 'The path to the GameMaker Studio 2 project to open.',
-    group: 'Open',
-    defaultValue: process.cwd(),
-    defaultOption: true,
-    type: String,
-  },
-  ide: {
-    description:
-      'The IDE version to use. Defaults to the last one used to open the project.',
-    group: 'Open',
-    optional: true,
-    type: String,
-  },
-  runtime: {
-    description: 'The runtime version to use.',
-    group: 'Open',
-    type: String,
-    optional: true,
-  },
-  programFiles: {
-    description:
-      'If you have installed GameMaker to somewhere besides the default C:\\Program Files\\ directory, specify that directory here.',
-    group: 'Open',
-    type: String,
-    optional: true,
-  },
-  debug: {
-    description: 'Enable debug logging.',
-    group: 'Open',
-    type: Boolean,
-    optional: true,
-  },
-  help: {
-    description: 'Show help.',
-    alias: 'h',
-    optional: true,
-    type: Boolean,
-  },
-};
-
-const args = parseArgs(argsConfig, {
-  helpArg: 'help',
-  headerContentSections: [
-    {
-      header: 'Stitch Open',
-      content:
-        'Open a GameMaker project using specified IDE and Runtime versions.\n\nThis command will install the IDE for you if the specified version is not already installed.\n\nIf no runtime version is specified, the IDE\'s specified "matching" runtime will be used.',
-    },
-  ],
-});
-
-// Get the target project
-const targetProjectPaths = await StitchProjectStatic.listYypFilesRecursively(
-  args.project,
-);
-
-ok(
-  targetProjectPaths.length > 0,
-  `No GameMaker projects found in ${args.project}`,
-);
-ok(
-  targetProjectPaths.length === 1,
-  `Multiple GameMaker projects found in ${args.project}. Provide a specific project path with the --project option.`,
-);
-
-if (args.debug) {
-  debug.enable('@bscotch/stitch-launcher:*');
-}
-
-await GameMakerLauncher.openProject(targetProjectPaths[0], {
-  ideVersion:
-    args.ide ||
-    (
-      await loadProjectFromArgs({
-        targetProject: targetProjectPaths[0],
-        readOnly: true,
-        force: true,
+export const openCommand = cli('open', {
+  description:
+    'Open a GameMaker project with a specific IDE and Runtime version.',
+  builder: (cli) =>
+    cli
+      .option('project', {
+        description: 'The path to the GameMaker Studio 2 project to open.',
+        default: {
+          value: process.cwd(),
+          description: 'Current directory',
+        },
+        type: 'string',
       })
-    ).ideVersion,
-  runtimeVersion: args.runtime,
-  programFiles: args.programFiles,
+      .option('ide', {
+        description:
+          'The IDE version to use. Defaults to the last one used to open the project.',
+        type: 'string',
+      })
+      .option('runtime', {
+        description: 'The runtime version to use.',
+        type: 'string',
+      })
+      .option('programFiles', {
+        description:
+          'If you have installed GameMaker to somewhere besides the default C:\\Program Files\\ directory, specify that directory here.',
+        type: 'string',
+      })
+      .option('debug', {
+        description: 'Enable debug logging.',
+        type: 'boolean',
+      }),
+  handler: async (args) => {
+    // Get the target project
+    const targetProjectPaths =
+      await StitchProjectStatic.listYypFilesRecursively(args.project);
+
+    ok(
+      targetProjectPaths.length > 0,
+      `No GameMaker projects found in ${args.project}`,
+    );
+    ok(
+      targetProjectPaths.length === 1,
+      `Multiple GameMaker projects found in ${args.project}. Provide a specific project path with the --project option.`,
+    );
+
+    if (args.debug) {
+      debug.enable('@bscotch/stitch-launcher:*');
+    }
+
+    await GameMakerLauncher.openProject(targetProjectPaths[0], {
+      ideVersion:
+        args.ide ||
+        (
+          await loadProjectFromArgs({
+            targetProject: targetProjectPaths[0],
+            readOnly: true,
+            force: true,
+          })
+        ).ideVersion,
+      runtimeVersion: args.runtime,
+      programFiles: args.programFiles,
+    });
+  },
 });

--- a/packages/core/src/cli/stitch-set-audio-group.ts
+++ b/packages/core/src/cli/stitch-set-audio-group.ts
@@ -1,31 +1,31 @@
 #!/usr/bin/env node
 import { oneline, undent } from '@bscotch/utility';
-import { program as cli } from 'commander';
+import { cli, chain } from 'cli-forge';
 import { addDebugOptions } from './lib/addDebugOption.js';
-import { assignAudioGroups, AssignCliOptions } from './lib/assign.js';
+import { assignAudioGroups } from './lib/assign.js';
 import options from './lib/cli-options.js';
 
-cli
-  .description(
-    undent`
+export const audioGroupCommand = cli('audio-group', {
+  description: undent`
   Assign all audios in a GMS IDE folder to a group.`,
-  )
-  .requiredOption(
-    '--folder <folder>',
-    undent`
-    This is the folder name shown in the GMS IDE, not the folder name of the actual audio file.
-    For example, a audio called "snd_title" is shown in the "Sounds" folder in the IDE, whereas
-    the actual audio file might be at "project/sounds/snd_title/snd_title.yy".
-  `,
-  )
-  .requiredOption(
-    '--group-name <name>',
-    oneline`
-    The name of the audio group. If it does not exist, it will be created.
-  `,
-  )
-  .option(...options.targetProject)
-  .option(...options.force);
-addDebugOptions(cli).parse(process.argv);
-
-await assignAudioGroups(cli.opts() as AssignCliOptions);
+  builder: (cli) =>
+    chain(cli, options.targetProject, options.force, addDebugOptions)
+      .option('folder', {
+        type: 'string',
+        description: undent`
+        This is the folder name shown in the GMS IDE, not the folder name of the actual audio file.
+        For example, a audio called "snd_title" is shown in the "Sounds" folder in the IDE, whereas
+        the actual audio file might be at "project/sounds/snd_title/snd_title.yy".
+      `,
+        required: true,
+      })
+      .option('groupName', {
+        type: 'string',
+        description: oneline`
+        The name of the audio group. If it does not exist, it will be created.
+      `,
+      }),
+  handler: async (opts) => {
+    await assignAudioGroups(opts);
+  },
+});

--- a/packages/core/src/cli/stitch-set-texture-group.ts
+++ b/packages/core/src/cli/stitch-set-texture-group.ts
@@ -1,31 +1,31 @@
 #!/usr/bin/env node
 import { oneline, undent } from '@bscotch/utility';
-import { program as cli } from 'commander';
+import { cli, chain } from 'cli-forge';
 import { addDebugOptions } from './lib/addDebugOption.js';
-import { AssignCliOptions, assignTextureGroups } from './lib/assign.js';
+import { assignTextureGroups } from './lib/assign.js';
 import options from './lib/cli-options.js';
 
-cli
-  .description(
-    undent`
+export const textureGroupCommand = cli('texture-group', {
+  description: undent`
   Assign all sprites in a GMS IDE folder to a group.`,
-  )
-  .requiredOption(
-    '--folder <folder>',
-    undent`
-    This is the folder name shown in the GMS IDE, not the folder name of the actual sprite file.
-    For example, a sprite called "sp_title" is shown in the "Sprites" folder in the IDE, whereas
-    the actual sprite file might be at "project/sprites/sp_title/sp_title.yy".
-  `,
-  )
-  .requiredOption(
-    '--group-name <name>',
-    oneline`
-    The name of the texture group. If it does not exist, it will be created.
-  `,
-  )
-  .option(...options.targetProject)
-  .option(...options.force);
-addDebugOptions(cli).parse(process.argv);
-
-await assignTextureGroups(cli.opts() as AssignCliOptions);
+  builder: (cli) =>
+    chain(cli, options.targetProject, options.force, addDebugOptions)
+      .option('folder', {
+        type: 'string',
+        required: true,
+        description: undent`
+        This is the folder name shown in the GMS IDE, not the folder name of the actual sprite file.
+        For example, a sprite called "sp_title" is shown in the "Sprites" folder in the IDE, whereas
+        the actual sprite file might be at "project/sprites/sp_title/sp_title.yy".
+      `,
+      })
+      .option('groupName', {
+        type: 'string',
+        description: oneline`
+        The name of the texture group. If it does not exist, it will be created.
+      `,
+      }),
+  handler: async (opts) => {
+    await assignTextureGroups(opts);
+  },
+});

--- a/packages/core/src/cli/stitch-set-version.ts
+++ b/packages/core/src/cli/stitch-set-version.ts
@@ -1,29 +1,30 @@
 #!/usr/bin/env node
 import { undent } from '@bscotch/utility';
-import { program as cli } from 'commander';
+import { cli, chain } from 'cli-forge';
 import { addDebugOptions } from './lib/addDebugOption.js';
 import options from './lib/cli-options.js';
-import version, { VersionOptions } from './lib/version.js';
+import version from './lib/version.js';
 
-cli
-  .description(
-    undent`
+export const versionCommand = cli('version', {
+  description: undent`
   Set the project version in all options files.
   (Note that the PS4 and Switch options files do not include the version
   and must be set outside of GameMaker).`,
-  )
-  .requiredOption(
-    '--project-version <version>',
-    undent`
+  builder: (cli) =>
+    chain(cli, options.targetProject, options.force, addDebugOptions).option(
+      'projectVersion',
+      {
+        type: 'string',
+        description: undent`
     Can use one of:
       + "0.0.0.0" syntax (exactly as GameMaker stores versions)
       + "0.0.0" syntax (semver without prereleases -- the 4th value will always be 0)
       + "0.0.0-rc.0" syntax (the 4th number will be the RC number)
       The four numbers will appear in all cases as the string "major.minor.patch.candidate"
   `,
-  )
-  .option(...options.targetProject)
-  .option(...options.force);
-addDebugOptions(cli).parse(process.argv);
-
-await version(cli.opts() as VersionOptions);
+      },
+    ),
+  handler: async (opts) => {
+    await version(opts);
+  },
+});

--- a/packages/core/src/cli/stitch-set.ts
+++ b/packages/core/src/cli/stitch-set.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
-import { program as cli } from 'commander';
+import { cli } from 'cli-forge';
 
-cli
-  .description('Modify metadata in GameMaker Studio 2 projects.')
-  .command('version', 'Modify the versions for all export platforms.')
-  .command('texture-group', 'Modify texture group assignments.')
-  .command('audio-group', 'Modify audio group assignments.')
-  .parse(process.argv);
+import { audioGroupCommand } from './stitch-set-audio-group.js';
+import { textureGroupCommand } from './stitch-set-texture-group.js';
+import { versionCommand } from './stitch-set-version.js';
+
+export const setCommand = cli('set', {
+  description: 'Modify metadata in GameMaker Studio 2 projects.',
+  builder: (cli) =>
+    cli.commands(audioGroupCommand, textureGroupCommand, versionCommand),
+});

--- a/packages/core/src/cli/stitch.ts
+++ b/packages/core/src/cli/stitch.ts
@@ -1,37 +1,33 @@
 #!/usr/bin/env node
-import { oneline } from '@bscotch/utility';
 import { prettifyErrorTracing, replaceFilePaths } from '@bscotch/validation';
-import { program as cli } from 'commander';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { cli } from 'cli-forge';
 import version from './lib/package-version.js';
+import { addCommand } from './stitch-add.js';
+import { archiveCommand } from './stitch-archive.js';
+import { deborkCommand } from './stitch-debork.js';
+import { issuesCommand } from './stitch-issues.js';
+import { mergeCommand } from './stitch-merge.js';
+import { lintCommand } from './stitch-lint.js';
+import { openCommand } from './stitch-open.js';
+import { setCommand } from './stitch-set.js';
 
 prettifyErrorTracing({ replaceFilePaths });
-const dir = dirname(fileURLToPath(import.meta.url));
+
+const stitch = cli('stitch', {
+  builder: (cli) =>
+    cli
+      .commands(
+        addCommand,
+        archiveCommand,
+        deborkCommand,
+        issuesCommand,
+        mergeCommand,
+        lintCommand,
+        openCommand,
+        setCommand,
+      )
+      .version(version),
+});
 
 // Kick it off
-cli
-  .executableDir(dir)
-  .version(version, '-v, --version')
-  .description('Stitch')
-  .command('archive', 'Create a .yyz archive of a GameMaker project.')
-  .command(
-    'open',
-    'Open a GameMaker project with a specific IDE and Runtime version.',
-  )
-  .command('issues', 'Create and manage issues to report to GameMaker.')
-  .command('merge', 'Merge two GameMaker Studio 2 projects together.')
-  .command(
-    'add',
-    'Create assets (e.g. sprites) using external resources (e.g. images).',
-  )
-  .command('set', 'Modify metadata in GameMaker Studio 2 projects.')
-  .command(
-    'debork',
-    oneline`
-    Run Stitch on the project without making any changes,
-    which will clean up some common issues and normalize the file content.
-  `,
-  )
-  .command('lint', 'Generate a lint report for a GameMaker Studio 2 project.')
-  .parse();
+await stitch.forge();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       change-case:
         specifier: 5.1.2
         version: 5.1.2
+      cli-forge:
+        specifier: 0.8.0
+        version: 0.8.0
       commander:
         specifier: 11.1.0
         version: 11.1.0
@@ -1212,6 +1215,12 @@ packages:
 
   /@chevrotain/utils@11.0.3:
     resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
+    dev: false
+
+  /@cli-forge/parser@0.8.0:
+    resolution: {integrity: sha512-+MWoele6Yjm60smxkCvQXxMSWQpec2rLhZLwaURefX6oTKVyisP53SD14CdRMI3muy8v1OjwzMcXt7Rei35chw==}
+    dependencies:
+      tslib: 2.6.3
     dev: false
 
   /@effect/data@0.17.1:
@@ -4108,6 +4117,22 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       restore-cursor: 3.1.0
+
+  /cli-forge@0.8.0:
+    resolution: {integrity: sha512-lJa0JmtiWFFUxNFzHJvqozX1xzz4fIScmyLESKEBaK1+QsxVHRQUpQwCgzGS+gWvdup1WEfrSwuDhEIkWdb/ew==}
+    hasBin: true
+    peerDependencies:
+      markdown-factory: 0.2.0
+      tsx: 4.19.0
+    peerDependenciesMeta:
+      markdown-factory:
+        optional: true
+      tsx:
+        optional: true
+    dependencies:
+      '@cli-forge/parser': 0.8.0
+      tslib: 2.6.3
+    dev: false
 
   /cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}


### PR DESCRIPTION
> Discussed briefly with @adam-coster on discord - this PR isn't necessarily meant to be merged, and is definitely not tested, but wanted to demo `cli-forge` and use this as a chance to spot holes in the new library. Would love feedback, but don't feel bad for closing it out 😄 

# Notes

`cli-forge` is a new typescript library for parsing CLI arguments that I'm working on. A main focal point for the library is nailing the typescript types and keeping good dev ergonomics. Docs can be found here: [cli-forge](https://craigory.dev/cli-forge).

In this repo `stitch` currently uses `commander` and `ts-command-line-args`, which requires a bit of casting around. This PR shows how the types improve without the need for casting.

## Oddities

- I needed to change the `build` script to manually specify `tsconfig.json` when running `tsc --build`. I'm not quite sure why this would have been necessary, but without it the build would fail on a Zod error in addition to some stuff with the new CLI typings. I don't think this is on `cli-forge`'s side, and its not on turborepo's either as the same behavior is exhibited when running `tsc --build` on the command line.

- Somehow the transition to `cli-forge` only changed the overall line count by 1. I'm not sure how this is possible, but I'm not going to complain.

  > 00:12 $ git commit -m "chore(core): replace commander and ts-command-line-args with cli-forge"
  >
  > [cli-forge 487a79c2] chore(core): replace commander and ts-command-line-args with cli-forge
  >
  > 25 files changed, 839 insertions(+), 838 deletions(-)

## Stitch Prior Architecture

- `stitch` was a CLI built using a combination of `commander`, and `ts-command-line-args` for arguments parsing, with `inquirer` for prompting.
- `stitch` used `commander`'s built-in `executableDir` to split commands into separate files that were discovered and loaded at runtime.

## Transition to CLI-Forge

At a per-command level, the transition was relatively straightforward but differed based on if the command was using `commander` or `ts-command-line-args`.

### Commander Commands

- `commander` uses a method chaining syntax to build commands, and then calls `parse` to execute the command.
- `cli-forge` uses a similar method chaining syntax within its command builders, but it is slightly different.

The options were translated losslessly, and command use should not change.

### TS-Command-Line-Args Commands

- `ts-command-line-args` uses a more declarative syntax to define commands and options. It consists of an object structure that is passed to the `parse` function.
- `cli-forge` does not support this syntax, so the rewrite was more involved.

There were a few things that looked a bit nicer in the `ts-command-line-args` syntax, but the new syntax is still quite clean. In `ts-command-line-args` the `type` property takes a function that is used to parse the value, which is a bit more flexible than the `type` property in `cli-forge`. In `cli-forge`, the `type` property is a string that maps to a built-in parser. For custom types and validation, `cli-forge` options have `validate` and `coerce` properties that can be used.

In cases where the `ts-command-line-args` type was used to map the type to a custom type, the `cli-forge` `validate` and `coerce` properties were used to achieve the same result.

### Prompting

There were a few points where a command did not define any cli level options and relied on prompting the user for input. In `stitch`, this was done using `inquirer` and was handled in the command file. `cli-forge` doesn't currently have any built in affordances for prompting, so all prompting was moved to the handler and left as is.

#### Issues Subcommands

- No CLI based arguments, all are prompt-based.
- Would like to add automatic prompting to cli-forge itself at some point, but for now, just moving all prompts to the handlers.
